### PR TITLE
**.md: fix various links, remove i3p

### DIFF
--- a/_addons/hol-ocl.md
+++ b/_addons/hol-ocl.md
@@ -1,5 +1,5 @@
 ---
-redirect: https://brucker.ch/projects/hol-ocl/index.en.html
+redirect: https://logicalhacking.com/software/hol-ocl/
 description: Interactive proof environment for the Object Constraint Language (OCL).
 category: Outdated
 ---

--- a/_addons/hol-testgen.md
+++ b/_addons/hol-testgen.md
@@ -1,5 +1,5 @@
 ---
-redirect: https://www.brucker.ch/projects/hol-testgen/index.en.html
+redirect: https://logicalhacking.com/software/hol-testgen/
 description: Environment for model-based Test-Generation. Models for unit-, sequence and reactive-sequence test scenarios can be written in HOL and tests are generated automatically.
 category: Outdated
 ---

--- a/_addons/i3p.md
+++ b/_addons/i3p.md
@@ -1,5 +1,0 @@
----
-redirect: http://www-pu.informatik.uni-tuebingen.de/i3p
-description: Interactive Interface for Isabelle.
-category: Outdated
----

--- a/courses.md
+++ b/courses.md
@@ -1,10 +1,10 @@
 # Isabelle Course Material
 
- - [Semantics via Isabelle](https://www21.in.tum.de/teaching/semantics/), Tobias Nipkow, 15 weeks with two 90 minute lectures per week
+ - [Semantics via Isabelle](https://www21.in.tum.de/teaching/semantics/WS24/), Tobias Nipkow, 15 weeks with two 90 minute lectures per week
    
    This is an MSc course on Semantics via Isabelle based on the [Concrete Semantics](https://concrete-semantics.in.tum.de/) book.
 
-- [Functional Data Structures](https://www21.in.tum.de/teaching/fds), Tobias Nipkow, 15 weeks with one 90 minute lecture per week
+- [Functional Data Structures](https://www21.in.tum.de/teaching/fds/SS24/), Tobias Nipkow, 15 weeks with one 90 minute lecture per week
 
   This is a course about functional data structures using Isabelle, based on material in the
   [Functional Algorithms, Verified!](https://functional-algorithms-verified.org/) book.


### PR DESCRIPTION
I've not found any information on whether it still exists anywhere. The other projects remain outdated, but are findable again.

The generic course links on www21.in.tum.de seem to have disappeared; instead I set them to links for concrete semesters when the courses were offered.